### PR TITLE
Add a page describing how to deploy or develop dms-view

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,7 @@ DEPENDENCIES
   github-pages (~> 204)
   jekyll-feed (~> 0.12)
   minima (~> 2.5)
+  minitest (~> 5.14.1)
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,11 +32,12 @@
         </ul>
         {% endif %}
         <!-- set up the table of contents -->
-        <a href="{{ "/docs/tutorial" }}">Tutorial<br></a>
-        <a href="{{ "/docs/dataupload" }}">Upload your own data<br></a>
-        <a href="{{ "/docs/casestudies" }}">Case Studies<br></a>
-        <a href="{{ "/docs/dms" }}">Deep Mutational Scanning primer<br></a>
 
+        <a href="{{ "/docs/tutorial" }}">Tutorial</a><br />
+        <a href="{{ "/docs/dataupload" }}">Upload your own data</a><br />
+        <a href="{{ "/docs/casestudies" }}">Case studies</a><br />
+        <a href="{{ "/docs/dms" }}">Deep Mutational Scanning primer</a><br />
+        <a href="{{ "/docs/deploy-or-develop" }}">Deploy or develop dms-view</a>
       </header>
       <section>
 

--- a/deploy-or-develop.md
+++ b/deploy-or-develop.md
@@ -32,3 +32,6 @@ http-server -a 127.0.0.1 -p 8000
 Note that `dms-view` loads data (CSVs, PDB files, the font for logo plots, etc.) by making HTTP requests to publicly available servers.
 This means that you cannot load local data from your computer unless it is in a directory that is visible to your web server.
 In the example above, all files from the top-level `dms-view` repository directory and below will be accessible to your web server.
+
+We welcome contributions to the `dms-view` code and documentation.
+[Consult our contributing guide for more details](https://github.com/dms-view/dms-view.github.io/blob/master/CONTRIBUTING.md).

--- a/deploy-or-develop.md
+++ b/deploy-or-develop.md
@@ -1,0 +1,34 @@
+---
+layout: post
+title: Deploy or develop dms-view
+permalink: /deploy-or-develop/
+---
+
+`dms-view` is a single-page web application that can be run from any web server.
+To deploy your own instance of the `dms-view` tool, clone [the dms-view repository](https://github.com/dms-view/dms-view.github.io) into a directory name of your choice within your existing web server's publicly available directory structure.
+
+To develop `dms-view` locally, you can use a lightweight web server such as [http-server](https://www.npmjs.com/package/http-server).
+You will need to [install npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) before you can download and install `http-server`.
+
+For example, our local development for `dms-view` works like this.
+
+1. Clone `dms-view` repository and change into its local directory.
+
+```bash
+git clone https://github.com/dms-view/dms-view.github.io.git
+cd dms-view.github.io
+```
+
+2. Start your web server on an internal address and port.
+
+```bash
+http-server -a 127.0.0.1 -p 8000
+```
+
+3. Navigate to http://127.0.0.1:8000 in your browser.
+
+4. Modify source code for `dms-view` as desired and refresh the local version in your browser to see your changes.
+
+Note that `dms-view` loads data (CSVs, PDB files, the font for logo plots, etc.) by making HTTP requests to publicly available servers.
+This means that you cannot load local data from your computer unless it is in a directory that is visible to your web server.
+In the example above, all files from the top-level `dms-view` repository directory and below will be accessible to your web server.


### PR DESCRIPTION
Adds documentation about how to deploy dms-view or develop it locally. This documentation includes a description of how to view local data by making those data accessible to a web server.

Resolves https://github.com/dms-view/dms-view.github.io/issues/153.