### PR TITLE
Note inability of loading data from Dropbox and Google Drive

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -103,7 +103,8 @@ This button will download an SVG or PNG of that panel only, not of the whole too
 <a href="https://dms-view.github.io" target="_blank">`dms_view`</a> uses three different files: the data file, the protein structure file, and the description file.
 You can upload your data using each file's specific form field. Please see the [data upload](/docs/dataupload) page for specifics on the file formats for each file.
 
-<a href="https://dms-view.github.io" target="_blank">`dms_view`</a> does not host the data itself, the files must be hosted on some other server such as [GitHub](https://www.github.com), [Dropbox](https://www.dropbox.com), or [Google Drive](https://www.google.com/drive/).
+<a href="https://dms-view.github.io" target="_blank">`dms_view`</a> does not host the data itself, the files must be hosted on some other server such as [GitHub](https://www.github.com).
+Note that `dms-view` cannot load data from [Dropbox](https://www.dropbox.com) or [Google Drive](https://www.google.com/drive/) links due to cross-origin resource restrictions implemented by those services.
 
 # Sample analysis
 


### PR DESCRIPTION
Instead of removing references to these popular services, this PR explicitly notes that we cannot load data from these services due to their CORS policies.

Resolves https://github.com/dms-view/dms-view.github.io/issues/154